### PR TITLE
Fixes #7: More consistent handling of nil

### DIFF
--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -12,8 +12,8 @@
   "Tools for interactive development with the REPL. This file should
   not be included in a production build of the application."
   (:require [clojure.tools.namespace.repl :refer [refresh refresh-all]]
+            [clojure.repl :refer [apropos dir doc find-doc pst source]]
+            [clojure.test :refer [run-tests run-all-tests]]
 
             [clojure.pprint :refer [pprint]]
-            [clojure.reflect :refer [reflect]]
-            [clojure.test :refer [run-tests run-all-tests]]
-            [clojure.repl :refer [apropos dir doc find-doc pst source]]))
+            [clojure.reflect :refer [reflect]]))

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any others, from this software.
 
-(defproject com.7theta/utilis "0.4.5"
+(defproject com.7theta/utilis "0.4.6"
   :description "Library of common utilities used in 7theta projects"
   :url "https://github.com/7theta/utilis"
   :license {:name "Eclipse Public License"

--- a/src/utilis/map.cljc
+++ b/src/utilis/map.cljc
@@ -54,10 +54,10 @@
     (compact {:a {:b [{} {:c {}}]}}) => nil"
   [m]
   (let [pred (fn [v] (or (nil? v)
-                         #?(:clj (and (seqable? v) (empty? v))
-                            :cljs (cond
-                                    (or (seq? v) (coll? v)) (empty? v)
-                                    (string? v) (blank? v)))))
+                        #?(:clj (and (seqable? v) (empty? v))
+                           :cljs (cond
+                                   (or (seq? v) (coll? v)) (empty? v)
+                                   (string? v) (blank? v)))))
         res (cond->> m
               (map? m) (reduce-kv (fn [m k v]
                                     (let [val (cond
@@ -79,9 +79,10 @@
            (if (every? map? maps)
              (apply merge-with m maps)
              (when (some identity maps)
-               (apply f maps)))) maps))
+               (apply f maps))))
+         (remove nil? maps)))
 
 (defn deep-merge
   "Like merge, but merges 'maps' recursively."
   [& maps]
-  (apply deep-merge-with (fn [& vals] (last vals)) maps))
+  (apply deep-merge-with (fn [& vals] (->> vals (filter identity) last)) maps))

--- a/test/utilis/map_test.cljc
+++ b/test/utilis/map_test.cljc
@@ -70,7 +70,14 @@
 
 (deftest deep-merge-with-should-work
   (checking "deep-merge-with should handle nil maps" 1 []
-            (is (nil? (deep-merge-with + nil nil nil))))
+            (is (nil? (deep-merge-with + nil nil nil)))
+            (is (= {:foo 1} (deep-merge-with + nil {:foo 1})))
+            (is (= {:foo 1} (deep-merge-with + {:foo 1} nil)))
+            (is (= {:foo 3 :bar 1} (deep-merge-with + {:foo 1} nil {:foo 2} nil {:bar 1}))))
+  (checking "deep-merge-with should handle empty maps" 1 []
+            (is (= {} (deep-merge-with + {} {} {})))
+            (is (= {:foo 1} (deep-merge-with + {} {:foo 1})))
+            (is (= {:foo 1} (deep-merge-with + {:foo 1} {}))))
   (checking "deep-merge-with should work the same as merge-with for shallow maps" (times 20)
             [maps (gen/vector (gen/map gen/any gen/int))]
             (is (= (apply merge-with + maps)
@@ -78,7 +85,16 @@
 
 (deftest deep-merge-should-work
   (checking "deep-merge should handle nil maps" 1 []
-            (is (nil? (deep-merge nil nil nil))))
+            (is (nil? (deep-merge nil nil nil)))
+            (is (= {:foo 1} (deep-merge nil {:foo 1})))
+            (is (= {:foo 1} (deep-merge {:foo 1} nil)))
+            (is (= {:foo 2 :bar 1} (deep-merge {:foo 1} nil {:foo 2} nil {:bar 1}))))
+  (checking "deep-merge should handle empty maps" 1 []
+            (is (= {} (deep-merge {} {} {})))
+            (is (= {:foo 1} (deep-merge {} {:foo 1})))
+            (is (= {:foo 1} (deep-merge {:foo 1} {}))))
+  (checking "deep-merge should take values from last map" 1 []
+            (is (= {:foo 3} (deep-merge {:foo 1} {:foo 2} {:foo 3} nil))))
   (checking "deep-merge should work the same as merge for shallow maps" (times 20)
             [maps (gen/vector (gen/map gen/any gen/int))]
             (is (= (apply merge maps)


### PR DESCRIPTION
The behaviour of `deep-merge` and `deep-merge-with` is more consistent
with `merge` and `merge-with` when passed nils and empty maps.