### PR TITLE
[Fixes #14] Support for xor

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any others, from this software.
 
-(defproject com.7theta/utilis "0.6.1"
+(defproject com.7theta/utilis "0.7.0"
   :description "Library of common utilities used in 7theta projects"
   :url "https://github.com/7theta/utilis"
   :license {:name "Eclipse Public License"

--- a/src/utilis/logic.cljc
+++ b/src/utilis/logic.cljc
@@ -1,0 +1,23 @@
+;;   Copyright (c) 7theta. All rights reserved.
+;;   The use and distribution terms for this software are covered by the
+;;   Eclipse Public License 1.0 (http://www.eclipse.org/legal/epl-v10.html)
+;;   which can be found in the LICENSE file at the root of this
+;;   distribution.
+;;
+;;   By using this software in any fashion, you are agreeing to be bound by
+;;   the terms of this license.
+;;   You must not remove this notice, or any others, from this software.
+
+(ns utilis.logic)
+
+(defmacro xor
+  "Evaluates exprs one at a time, from left to right. If a form
+  returns a logical true value, xor returns that value if no other
+  value also evaluates to a logical true value, otherwise it returns
+  nil"
+  ([] nil)
+  ([x & next]
+   `(let [first# ~x]
+      (if first#
+        (when-not (or ~@next) first#)
+        (xor ~@next)))))

--- a/test/utilis/logic_test.clj
+++ b/test/utilis/logic_test.clj
@@ -1,0 +1,27 @@
+;;   Copyright (c) 7theta. All rights reserved.
+;;   The use and distribution terms for this software are covered by the
+;;   Eclipse Public License 1.0 (http://www.eclipse.org/legal/epl-v10.html)
+;;   which can be found in the LICENSE file at the root of this
+;;   distribution.
+;;
+;;   By using this software in any fashion, you are agreeing to be bound by
+;;   the terms of this license.
+;;   You must not remove this notice, or any others, from this software.
+
+(ns utilis.logic-test
+  (:require [utilis.logic :refer [xor]]
+            [clojure.test.check.generators :as gen]
+            [com.gfredericks.test.chuck :refer [times]]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]]
+            [clojure.test :refer [deftest is]]))
+
+(deftest xor-works
+  (checking "xor should return nil when passed no arguments" 1 []
+            (is (nil? (xor))))
+  (checking "xor should handle multiple arguments" (times 20)
+            [s (gen/vector (gen/one-of [gen/int gen/boolean (gen/return nil)
+                                        gen/keyword gen/string]))]
+            (is (= (eval `(xor ~@s))
+                   (when (not-empty s)
+                     (let [true-vals (filter identity s)]
+                       (when (= 1 (count true-vals)) (first true-vals))))))))


### PR DESCRIPTION
Tests only run in clojure because of the need to use eval.