### PR TITLE
Added ensure-ends-with for strings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,17 +8,17 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any others, from this software.
 
-(defproject com.7theta/utilis "0.7.0"
+(defproject com.7theta/utilis "0.8.0"
   :description "Library of common utilities used in 7theta projects"
   :url "https://github.com/7theta/utilis"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.8.51"]]
+                 [org.clojure/clojurescript "1.9.93"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :plugins [[lein-cljsbuild "1.1.3"]
-                             [lein-doo "0.1.6"]]
-                   :dependencies [[reloaded.repl "0.2.1"]
+                             [lein-doo "0.1.7"]]
+                   :dependencies [[reloaded.repl "0.2.2"]
                                   [org.clojure/tools.namespace "0.2.11"]
                                   [org.clojure/test.check "0.9.0"]
                                   [com.gfredericks/test.chuck "0.2.6"]]

--- a/src/utilis/coll.cljc
+++ b/src/utilis/coll.cljc
@@ -25,11 +25,11 @@
 
 (defn only
   "Returns the first element from 's' iff it's the only element in 's'.
-  If 's' is empty or contains more than 1 element, an IllegalaAgumentException
+  If 's' does not contain exactly 1 element, an IllegalAgumentException
   or js/Error is thrown. The message for the exceptions can be optionally
   specified."
   ([s]
-   (only s "Sequence contains more than 1 element"))
+   (only s "Sequence does not contain exactly 1 element"))
   ([s exception-message]
    (if (= 1 (count s))
      (first s)

--- a/src/utilis/string.cljc
+++ b/src/utilis/string.cljc
@@ -24,3 +24,8 @@
     (boolean
      #?(:clj (re-matches re s)
         :cljs (.exec (js/RegExp. (.-source re)) s)))))
+
+(defn ensure-ends-with
+  "Add 'suffix' to 's' if 's' does not already end with 'suffix'"
+  [s suffix]
+  (cond-> s (not (st/ends-with? s suffix)) (str suffix)))

--- a/test/utilis/string_test.cljc
+++ b/test/utilis/string_test.cljc
@@ -9,7 +9,7 @@
 ;;   You must not remove this notice, or any others, from this software.
 
 (ns utilis.string-test
-  (:require  [utilis.string :refer [collapse-whitespace numeric?]]
+  (:require  [utilis.string :refer [collapse-whitespace numeric? ensure-ends-with]]
              [clojure.string :as st]
              [clojure.test.check.generators :as gen]
              [com.gfredericks.test.chuck :refer [times]]
@@ -45,3 +45,13 @@
                                     :cljs (.exec (js/RegExp. (.-source numeric-re)) %))))
                   gen/string)]
               (is (= false (numeric? s))))))
+
+(deftest ensure-ends-with-should-work
+  (checking "ensure-ends-with should handle any kind of strings" (times 50)
+            [s gen/string
+             suffix gen/string]
+            (if (st/ends-with? s suffix)
+              (= s (ensure-ends-with s suffix))
+              (= (str s suffix)
+                 (ensure-ends-with s suffix)
+                 (ensure-ends-with (ensure-ends-with s suffix) suffix)))))


### PR DESCRIPTION
Function to ensure that a string ends with a specified suffix. If the
suffix is already present, the string is returned as is, otherwise a new
string is returned with the suffix added.