### PR TITLE
Updated dependencies and made pulsar friendly

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,20 +8,20 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any others, from this software.
 
-(defproject com.7theta/utilis "0.8.1"
+(defproject com.7theta/utilis "0.8.2"
   :description "Library of common utilities used in 7theta projects"
   :url "https://github.com/7theta/utilis"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.93"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
-                   :plugins [[lein-cljsbuild "1.1.3"]
+                   :plugins [[lein-cljsbuild "1.1.4"]
                              [lein-doo "0.1.7"]]
-                   :dependencies [[reloaded.repl "0.2.2"]
+                   :dependencies [[org.clojure/clojurescript "1.9.229"]
+                                  [reloaded.repl "0.2.3"]
                                   [org.clojure/tools.namespace "0.2.11"]
                                   [org.clojure/test.check "0.9.0"]
-                                  [com.gfredericks/test.chuck "0.2.6"]]
+                                  [com.gfredericks/test.chuck "0.2.7"]]
                    :source-paths ["dev"]}}
   :clean-targets ^{:protect false} ["out" "target"]
   :cljsbuild {:builds [{:id "test"


### PR DESCRIPTION
Pulsar seemed to have issues with the clojurescript dependency listed in
the main dependencies section. Since any clojurescript project using
utilis will have it's own clojurescript dependency, it was moved into
the dev dependencies in utilis.