### PR TITLE
Add js/get, js/call, js/call-in.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any others, from this software.
 
-(defproject com.7theta/utilis "1.5.1"
+(defproject com.7theta/utilis "1.6.0"
   :description "Library of common utilities used in 7theta projects"
   :url "https://github.com/7theta/utilis"
   :license {:name "Eclipse Public License"

--- a/src/utilis/js.cljs
+++ b/src/utilis/js.cljs
@@ -9,10 +9,24 @@
 ;;   You must not remove this notice, or any others, from this software.
 
 (ns utilis.js
-  (:refer-clojure :exclude [get-in])
+  (:refer-clojure :exclude [get-in get])
   (:require [goog.object :as go]))
 
+(defn get
+  [object key]
+  (go/get object (clj->js key)))
+
 (defn get-in
-  ([object path]
-   (when object
-     (go/getValueByKeys object (clj->js path)))))
+  [object path]
+  (when object
+    (go/getValueByKeys object (clj->js path))))
+
+(defn call
+  [object key & args]
+  (apply js-invoke object (clj->js key) (clj->js args)))
+
+(defn call-in
+  [object path & args]
+  (if (= 1 (count path))
+    (apply call object (first path) args)
+    (apply call (get-in object (drop-last path)) (last path) args)))

--- a/src/utilis/js.cljs
+++ b/src/utilis/js.cljs
@@ -14,7 +14,8 @@
 
 (defn get
   [object key]
-  (go/get object (clj->js key)))
+  (when object
+    (go/get object (clj->js key))))
 
 (defn get-in
   [object path]


### PR DESCRIPTION
Added `get`, `call` and `call-in` to utilis.js namespace. These functions are necessary for the same reasons as `get-in` so as to have advanced compilation work properly and consistently.

Usage is as you would expect, e.g.
```clojure
(j/get my-js-obj :foo) ;; access "foo" property on js object
(j/call my-js-obj :foo) ;; invoke "foo" function on js object
(j/call-in my-js-obj [:foo :bar]) ;; invoke function on js object at path ["foo" "bar"]
```